### PR TITLE
chore(eslintrc): allow usage of function

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -182,7 +182,7 @@ module.exports = {
         "no-unmodified-loop-condition": "error",
         "no-unneeded-ternary": "error",
         "no-unused-expressions": "error",
-        "no-use-before-define": "error",
+        "no-use-before-define": ["error", "nofunc"],
         "no-useless-call": "error",
         "no-useless-computed-key": "error",
         "no-useless-concat": "error",


### PR DESCRIPTION
Allow usage of functions before their declaration
Improves code readability

eslint reference: http://eslint.org/docs/rules/no-use-before-define#options